### PR TITLE
npm start to watch and serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   },
   "scripts": {
     "build": "NODE_ENV=production browserify main.js | uglifyjs -cm > public/bundle.js",
-    "start": "ecstatic -p 8000 public",
-    "watch": "watchify main.js -o public/bundle.js -dv"
+    "start": "npm run watch & npm run serve",
+    "watch": "watchify main.js -o public/bundle.js -dv",
+    "serve": "ecstatic -p 8000 public"
   },
   "dependencies": {
     "babelify": "^6.1.3",


### PR DESCRIPTION
Instead of requiring users run:

```bash
npm run watch & npm start
```

We can add a serve script, and have npm start run watch and serve. Makes life that little bit easier